### PR TITLE
Updated method names to make the mod compatible with VintageStory 1.20

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -5,7 +5,7 @@
   "authors": [ "Nexrem", "Lyrthras" ],
   "description": "Swap left and right mouse buttons as well as their corresponding prompts",
   "website": "https://github.com/SexualReptilians/vintagestory-mouseswapper",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "side": "Client",
   "dependency": {
     "game": ""

--- a/src/MouseSwapper.cs
+++ b/src/MouseSwapper.cs
@@ -61,7 +61,7 @@ namespace MouseSwapper
         static void Postfix(MouseEvent args, int __state, ref MouseButtonState ___InWorldMouseState)
         {
             // Make sure to drop handled events
-            if (args.Handled) return;
+            if (args.Handled || !(___InWorldMouseState.Left || ___InWorldMouseState.Right)) return;
 
             // Revert mouse state to the way it was before the call
             ___InWorldMouseState.Left = Convert.ToBoolean(__state & 1);
@@ -94,6 +94,9 @@ namespace MouseSwapper
 
         static void Postfix(MouseEvent args, int __state, ref MouseButtonState ___InWorldMouseState)
         {
+            // Make sure to drop handled events
+            if (args.Handled || !(___InWorldMouseState.Left || ___InWorldMouseState.Right)) return;
+            
             // Revert mouse state to the way it was before the call
             ___InWorldMouseState.Left = Convert.ToBoolean(__state & 1);
             ___InWorldMouseState.Right = Convert.ToBoolean(__state & 2);

--- a/src/MouseSwapper.cs
+++ b/src/MouseSwapper.cs
@@ -48,7 +48,7 @@ namespace MouseSwapper
     }
 
     [HarmonyPatch(typeof(ClientMain))]
-    [HarmonyPatch("OnMouseDown")]
+    [HarmonyPatch("OnMouseDownRaw")]
     class MouseDownPatch
     {
         static void Prefix(out int __state, ref MouseButtonState ___InWorldMouseState)
@@ -82,7 +82,7 @@ namespace MouseSwapper
 
 
     [HarmonyPatch(typeof(ClientMain))]
-    [HarmonyPatch("OnMouseUp")]
+    [HarmonyPatch("OnMouseUpRaw")]
     class MouseUpPatch
     {
         static void Prefix(out int __state, ref MouseButtonState ___InWorldMouseState)


### PR DESCRIPTION
Changed method names patched with Harmony from "OnMouseDown" and "OnMouseUp" to "OnMouseDownRaw" and "OnMouseUpRaw". This makes the mod compatible with VS 1.20.